### PR TITLE
Allow override of static method Dijkstra::distance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "ext-bcmath": "*"
     },
     "require-dev": {
         "ext-gd": "*",

--- a/src/Dijkstra.php
+++ b/src/Dijkstra.php
@@ -130,9 +130,9 @@ class Dijkstra
          * ENDIF
          */
         if (! $this->weights[$child->ref]['passed']
-            && ($this->weights[$parent->ref]['weight'] + self::distance($parent, $child) < $this->weights[$child->ref]['weight']
+            && ($this->weights[$parent->ref]['weight'] + static::distance($parent, $child) < $this->weights[$child->ref]['weight']
                 || $this->weights[$child->ref]['weight'] === -1)) {
-            $this->weights[$child->ref]['weight'] = $this->weights[$parent->ref]['weight'] + self::distance($parent, $child);
+            $this->weights[$child->ref]['weight'] = $this->weights[$parent->ref]['weight'] + static::distance($parent, $child);
             $this->predecessors[$child->ref]['previous'] = $parent;
         }
     }


### PR DESCRIPTION
I've encountered an issue with function `bcpow`.

```
Attempted to call function "bcpow" from namespace "Bmichotte\Dijkstra".
```

To fix this problem, I'm overriding the `distance` static method to remove calls to bcpow, that is not available out of the box under Linux (https://www.php.net/manual/en/bc.installation.php), and because I don't use Point coordinates positioning to calculate the shortest paths.

But, to allow static override, we must change calls to `self` by `static`.